### PR TITLE
Hotfix 1.0.8: disconnect settings signals in disable()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ This project follows industry-standard software engineering principles:
 - Keep information scannable and easy to navigate
 - Prioritize clarity and brevity over exhaustive detail
 
+### No AI Attribution in Code
+- **Do NOT add "Generated with Claude Code" / "Co-Authored-By: Claude" style adverts in code comments**
+- README.md already discloses AI-assisted development (Copilot + Claude Code) — no need to repeat it per-file or per-function
+- Commit messages should also skip AI attribution footers for the same reason
+
 ### Examples in This Codebase:
 - **DRY**: IconHelper eliminated 8+ duplicate if/else blocks for icon style checks
 - **KISS**: Each lib/ module is focused on one responsibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Ping Bot will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.8] - 2026-07-03
+
+### Fixed
+- Settings signal handlers connected in `enable()` are now properly disconnected in `disable()`, per GNOME Shell extension review guidelines
+
 ## [1.0.7] - 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ gnome-extensions info pingbot@gudlenieks.lv
 
 ## Recent Updates
 
-**Version 1.0.7** (June 30, 2026) - Added IP/ICMP ping monitoring for devices without a web server, GNOME Shell 50 support, and a type selector in the preferences add-target row.
+**Version 1.0.8** (July 3, 2026) - Fixed settings signal handlers not being disconnected on disable, per GNOME Shell extension review guidelines.
 
 See [CHANGELOG.md](CHANGELOG.md) for complete version history.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ Enable the extension and check for errors:
 gnome-extensions info pingbot@gudlenieks.lv
 ```
 
+### Testing for Common Review Issues
+
+Before submitting a new version to [extensions.gnome.org](https://extensions.gnome.org), run [Shexli](https://gitlab.gnome.org/GNOME/shexli) locally to catch common packaging and review issues early:
+
+```bash
+virtualenv venv
+. venv/bin/activate
+pip install -U shexli
+shexli pingbot@gudlenieks.lv.zip
+```
+
 ## Known Limitations
 
 - URLs must be accessible via HTTP/HTTPS GET requests

--- a/extension.js
+++ b/extension.js
@@ -62,6 +62,8 @@ export default class PingBotExtension extends Extension {
 
     disable() {
         // stop actions and remove ux elements
+        this._disconnectSignals();
+
         if (this._pingScheduler) {
             this._pingScheduler.stop();
             this._pingScheduler = null;
@@ -91,23 +93,33 @@ export default class PingBotExtension extends Extension {
     }
 
     _connectSignals() {
-        this._settings.connect('changed::ping-urls', () => {
-            const urls = this._settings.get_strv('ping-urls');
-            this._logger.debug('Settings changed: ping-urls updated', { urls });
-            this._panelIndicator.buildMenu();
-            // Restart scheduler to ping new URLs immediately
-            this._pingScheduler.start();
-        });
-        this._settings.connect('changed::url-statuses', () => {
-            this._updateMainStatus();
-            this._panelIndicator.buildMenu();
-        });
-        this._settings.connect('changed::ping-interval', () => {
-            const interval = this._settings.get_int('ping-interval');
-            this._logger.debug(`Settings changed: ping-interval updated to ${interval} minutes`);
-            // Restart scheduler to apply new interval
-            this._pingScheduler.start();
-        });
+        this._settingsSignalIds = [
+            this._settings.connect('changed::ping-urls', () => {
+                const urls = this._settings.get_strv('ping-urls');
+                this._logger.debug('Settings changed: ping-urls updated', { urls });
+                this._panelIndicator.buildMenu();
+                // Restart scheduler to ping new URLs immediately
+                this._pingScheduler.start();
+            }),
+            this._settings.connect('changed::url-statuses', () => {
+                this._updateMainStatus();
+                this._panelIndicator.buildMenu();
+            }),
+            this._settings.connect('changed::ping-interval', () => {
+                const interval = this._settings.get_int('ping-interval');
+                this._logger.debug(`Settings changed: ping-interval updated to ${interval} minutes`);
+                // Restart scheduler to apply new interval
+                this._pingScheduler.start();
+            }),
+        ];
+    }
+
+    _disconnectSignals() {
+        if (this._settings && this._settingsSignalIds) {
+            for (const id of this._settingsSignalIds)
+                this._settings.disconnect(id);
+        }
+        this._settingsSignalIds = null;
     }
 
     _updateMainStatus() {

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Ping Bot",
   "description": "Monitor your important websites and devices at a glance. Add URLs, IP addresses or hostnames to your list, see status indicators in the panel:\n🟢 - Everything is ok, all targets reachable.\n🟡 - Unknown or no network.\n🔴 - Some target is not reachable.\n\nNo external services, no API keys, or accounts needed.\nSimilar to uptime robot services, but from your local machine.",
   "uuid": "pingbot@gudlenieks.lv",
-  "version": 7,
+  "version": 8,
   "shell-version": [ "45", "46", "47", "48", "49", "50" ],
   "settings-schema": "org.gnome.shell.extensions.pingbot",
   "url": "https://github.com/lauzis/pingbot",


### PR DESCRIPTION
## Summary
- `shexli` (the new GNOME EGO static analyzer) flagged `EGO-L-003`: signal handlers connected on `this._settings` in `enable()`/`_connectSignals()` were never disconnected in `disable()`.
- Store the three handler IDs and disconnect them via a new `_disconnectSignals()` called at the top of `disable()`.
- Bump version to 1.0.8 and update CHANGELOG/README.

## Test plan
- [x] Ran `shexli` against the rebuilt release zip — 0 findings (previously 1 warning)
- [ ] Manually verify enable/disable cycle in GNOME Shell (Looking Glass / `dbus-run-session -- gnome-shell --nested`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings changes are now cleaned up properly when the extension is disabled, preventing leftover listeners during shutdown.

* **Documentation**
  * Updated the changelog and README to reflect version 1.0.8 and the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->